### PR TITLE
Fixed always failing health check

### DIFF
--- a/kurento-media-server/Dockerfile
+++ b/kurento-media-server/Dockerfile
@@ -58,6 +58,12 @@ RUN apt-get update \
         gnupg \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install curl, needed for health check
+RUN apt-get update \
+ && apt-get install --yes \
+        curl \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Configure apt-get
 # * Disable installation of recommended and suggested packages
 # * Add Kurento package repository


### PR DESCRIPTION
Dockerfile defines health check script which depends on curl. But curl was missing so the healthcheck script always returns error code which results in docker always considering kurento container not ready.