### PR TITLE
Correct unhealthy kms container status.

### DIFF
--- a/kurento-media-server/healthchecker.sh
+++ b/kurento-media-server/healthchecker.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 # Bash options for strict error checking
-set -o errexit -o errtrace -o pipefail -o nounset
-
+ set -o errexit
+ set -o errtrace 
+ set -o pipefail
+ set -o nounset
+ 
 RC="$(curl \
     --silent \
     --no-buffer \


### PR DESCRIPTION
At the moment, the kms docker container is always unhealthy caused by syntax error in script sh for container health check. 